### PR TITLE
query parsing in judgeName field

### DIFF
--- a/saos-search/src/main/java/pl/edu/icm/saos/search/search/service/JudgmentCriteriaTransformer.java
+++ b/saos-search/src/main/java/pl/edu/icm/saos/search/search/service/JudgmentCriteriaTransformer.java
@@ -37,10 +37,10 @@ public class JudgmentCriteriaTransformer implements CriteriaTransformer<Judgment
         list.add(criterionTransformer.transformDateRangeCriterion(
                 JudgmentIndexField.JUDGMENT_DATE, criteria.getDateFrom(), criteria.getDateTo()));
         list.add(criterionTransformer.transformMultivaluedEnumCriterion(JudgmentIndexField.JUDGMENT_TYPE, criteria.getJudgmentTypes(), Operator.OR));
-        list.add(criterionTransformer.transformCriterion(JudgmentIndexField.JUDGE_NAME, criteria.getJudgeName()));
+        list.add(criterionTransformer.transformCriterionWithParsing(JudgmentIndexField.JUDGE_NAME, criteria.getJudgeName()));
         list.add(criterionTransformer.transformMultivaluedCriterion(JudgmentIndexField.KEYWORD, criteria.getKeywords(), Operator.AND));
-        list.add(criterionTransformer.transformCriterion(JudgmentIndexField.LEGAL_BASE, criteria.getLegalBase()));
-        list.add(criterionTransformer.transformCriterion(JudgmentIndexField.REFERENCED_REGULATION, criteria.getReferencedRegulation()));
+        list.add(criterionTransformer.transformCriterionWithParsing(JudgmentIndexField.LEGAL_BASE, criteria.getLegalBase()));
+        list.add(criterionTransformer.transformCriterionWithParsing(JudgmentIndexField.REFERENCED_REGULATION, criteria.getReferencedRegulation()));
         list.add(criterionTransformer.transformCriterion(JudgmentIndexField.CASE_NUMBER, criteria.getCaseNumber()));
         
         String criteriaString = list.stream()

--- a/saos-search/src/test/java/pl/edu/icm/saos/search/search/service/JudgmentCriteriaTransformerTest.java
+++ b/saos-search/src/test/java/pl/edu/icm/saos/search/search/service/JudgmentCriteriaTransformerTest.java
@@ -44,6 +44,7 @@ public class JudgmentCriteriaTransformerTest {
                 { "*:*", new JudgmentCriteria(" ") },
                 
                 { "+judgeName:Nowak", new JudgmentCriteriaBuilder().withJudgeName("Nowak").build() },
+                { "+judgeName:Adam +judgeName:Nowak", new JudgmentCriteriaBuilder().withJudgeName("Adam Nowak").build() },
                 { "+judgeName:\"Adam Nowak\"", new JudgmentCriteriaBuilder().withJudgeName("\"Adam Nowak\"").build() },
                 { "+(judgeName:Nowak judgeName:Kowalski)", new JudgmentCriteriaBuilder().withJudgeName("Nowak or Kowalski").build() },
                 { "+keyword:word", new JudgmentCriteriaBuilder().withKeyword("word").build() },

--- a/saos-search/src/test/java/pl/edu/icm/saos/search/search/service/JudgmentCriteriaTransformerTest.java
+++ b/saos-search/src/test/java/pl/edu/icm/saos/search/search/service/JudgmentCriteriaTransformerTest.java
@@ -40,13 +40,18 @@ public class JudgmentCriteriaTransformerTest {
     public static Object[][] criterionData() {
         return new Object[][] {
                 { "+content:word", new JudgmentCriteria("word") },
+                { "+(content:word1 content:word2)", new JudgmentCriteria("word1 or word2") },
                 { "*:*", new JudgmentCriteria(" ") },
                 
-                { "+judgeName:Adam\\ Nowak", new JudgmentCriteriaBuilder().withJudgeName("Adam Nowak").build() },
+                { "+judgeName:Nowak", new JudgmentCriteriaBuilder().withJudgeName("Nowak").build() },
+                { "+judgeName:\"Adam Nowak\"", new JudgmentCriteriaBuilder().withJudgeName("\"Adam Nowak\"").build() },
+                { "+(judgeName:Nowak judgeName:Kowalski)", new JudgmentCriteriaBuilder().withJudgeName("Nowak or Kowalski").build() },
                 { "+keyword:word", new JudgmentCriteriaBuilder().withKeyword("word").build() },
                 { "+keyword:word1 +keyword:word2", new JudgmentCriteriaBuilder().withKeyword("word1").withKeyword("word2").build() },
                 { "+legalBases:someLegalBase", new JudgmentCriteriaBuilder().withLegalBase("someLegalBase").build() },
+                { "+legalBases:\"some legal base\"", new JudgmentCriteriaBuilder().withLegalBase("\"some legal base\"").build() },
                 { "+referencedRegulations:someReferencedRegulation", new JudgmentCriteriaBuilder().withReferencedRegulation("someReferencedRegulation").build() },
+                { "+referencedRegulations:\"some referenced regulation\"", new JudgmentCriteriaBuilder().withReferencedRegulation("\"some referenced regulation\"").build() },
                 
                 { "+judgmentDate:[2014-04-01T00:00:00Z TO *]", new JudgmentCriteriaBuilder().withDateFrom(FIRST_DATE).build() },
                 { "+judgmentDate:[* TO 2014-04-01T23:59:59Z]", new JudgmentCriteriaBuilder().withDateTo(FIRST_DATE).build() },

--- a/saos-search/src/test/java/pl/edu/icm/saos/search/search/service/JudgmentSearchServiceTest.java
+++ b/saos-search/src/test/java/pl/edu/icm/saos/search/search/service/JudgmentSearchServiceTest.java
@@ -108,7 +108,10 @@ public class JudgmentSearchServiceTest {
             
             { Lists.newArrayList(1961l), new JudgmentCriteriaBuilder().withJudgeName("Jacek Witkowski").build() },
             { Lists.newArrayList(1961l), new JudgmentCriteriaBuilder().withJudgeName("Witkowski").build() },
+            { Lists.newArrayList(1961l), new JudgmentCriteriaBuilder().withJudgeName("Witkowski Kunecka").build() },
             { Lists.newArrayList(1961l), new JudgmentCriteriaBuilder().withJudgeName("Elżbieta Kunecka").build() },
+            { Lists.newArrayList(), new JudgmentCriteriaBuilder().withJudgeName("\"Irena Kunecka\"").build() },
+            { Lists.newArrayList(), new JudgmentCriteriaBuilder().withJudgeName("Ewelina Kunecka").build() },
             { Lists.newArrayList(), new JudgmentCriteriaBuilder().withJudgeName("Adam Nowak").build() },
             
             { Lists.newArrayList(41808l), new JudgmentCriteriaBuilder().withLegalBase("art. 227 kk").build() },


### PR DESCRIPTION
apply query parsing to judgeName, referencedRegulations and legalBases fields
see: #451 