### PR TITLE
#692. Import dirs defaults

### DIFF
--- a/saos-webapp/src/main/resources/saos.default.properties
+++ b/saos-webapp/src/main/resources/saos.default.properties
@@ -45,25 +45,25 @@ import.commonCourt.dates.timeZoneId = Europe/Warsaw
 import.commonCourt.court.xml.filePath = /temp/commonCourts.xml
 
 # path to directory with supreme court judgments import data files
-import.judgments.supremeCourt.dir
+import.judgments.supremeCourt.dir=${user.home}/saos/source/supreme-court/metadata
 # path to directory with supreme court judgments import content files
-import.judgments.supremeCourt.content.dir
+import.judgments.supremeCourt.content.dir=${user.home}/saos/source/supreme-court/content
 # path to directory with downloaded supreme court judgments import content files
-import.judgments.supremeCourt.download.dir
+import.judgments.supremeCourt.download.dir=${user.home}/saos/download/supreme-court/content
 
 # path to directory with constitutional tribunal judgments import data files
-import.judgments.constitutionalTribunal.dir
+import.judgments.constitutionalTribunal.dir=${user.home}/saos/source/const-tribunal/metadata
 # path to directory with constitutional tribunal judgments import content files
-import.judgments.constitutionalTribunal.content.dir
+import.judgments.constitutionalTribunal.content.dir=${user.home}/saos/source/const-tribunal/content
 # path to directory with downloaded constitutional tribunal judgments import content files
-import.judgments.constitutionalTribunal.download.dir
+import.judgments.constitutionalTribunal.download.dir=${user.home}/saos/download/const-tribunal/content
 
 # path to directory with national appeal chamber judgments import data files
-import.judgments.nationalAppealChamber.dir
+import.judgments.nationalAppealChamber.dir=${user.home}/saos/source/appeal-chamber/metadata
 # path to directory with national appeal chamber judgments import content files
-import.judgments.nationalAppealChamber.content.dir
+import.judgments.nationalAppealChamber.content.dir=${user.home}/saos/source/appeal-chamber/content
 # path to directory with downloaded national appeal chamber judgments import content files
-import.judgments.nationalAppealChamber.download.dir
+import.judgments.nationalAppealChamber.download.dir=${user.home}/saos/download/appeal-chamber/content
 
 # path to base directory where judgment content files are stored
 judgments.content.dir=${user.home}/saos/judgments/dir


### PR DESCRIPTION
On devel environment I've changed properties to:
`import.judgments.supremeCourt.download.dir = ~/workspace/download/supreme-court/`
`import.judgments.supremeCourt.dir` and `import.judgments.supremeCourt.content.dir` - no change (`~/import/supreme-court/json/`, `~/import/supreme-court/src/`)
analogically for constitutionalTribunal and nationalAppealChamber
`judgments.content.dir = ~/workspace/judgments/`